### PR TITLE
Fix for dashed MAC string

### DIFF
--- a/nMAC/MainActivity.cs
+++ b/nMAC/MainActivity.cs
@@ -184,14 +184,16 @@ To be able to revert anything you do here, a backup of your current MAC binary f
 
             for (int i = 0, u = 0; i < MAC.Length; i++)
             {
-                @byte += MAC[i];
-                if (@byte.Length < 2)
-                    continue;
-                else
+                if (Uri.IsHexDigit(MAC[i]))
                 {
-                    MACArray[u++] = @byte;
-                    @byte = string.Empty;
-                    i++;
+                    @byte += MAC[i];
+                    if (@byte.Length < 2)
+                        continue;
+                    else
+                    {
+                        MACArray[u++] = @byte;
+                        @byte = string.Empty;
+                    }
                 }
             }
 

--- a/nMAC/MainActivity.cs
+++ b/nMAC/MainActivity.cs
@@ -191,6 +191,7 @@ To be able to revert anything you do here, a backup of your current MAC binary f
                 {
                     MACArray[u++] = @byte;
                     @byte = string.Empty;
+                    i++;
                 }
             }
 


### PR DESCRIPTION
Skip processing the dash symbol in the MAC address string - fixes issue #4 